### PR TITLE
Pinning compress_pickle version.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -39,6 +39,6 @@ dependencies:
     - docformatter==1.3.1
     - "gym>=0.17.0,<0.18.0"
     - pyquaternion==0.9.9
-    - compress_pickle
+    - compress_pickle==1.2.0
     - lru-dict
 prefix: /anaconda3/envs/thor-rearrange

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ scipy
 stringcase
 lru-dict
 networkx
+compress-pickle==1.2.0


### PR DESCRIPTION
The 2.0.0 version of compress_pickle seems to have some issue where it mangles input paths, to avoid this we pin the 1.2.0 version.