### PR TITLE
minor energy metrics fix

### DIFF
--- a/rearrange/environment.py
+++ b/rearrange/environment.py
@@ -1009,7 +1009,7 @@ class RearrangeTHOREnvironment:
         if pose_diff["broken"]:
             return 1.0
 
-        if pose_diff["openness_diff"] is None:
+        if pose_diff["openness_diff"] is None or goal_pose["pickupable"]:
             gbb = np.array(goal_pose["bounding_box"])
             cbb = np.array(cur_pose["bounding_box"])
 


### PR DESCRIPTION
In cases where an object (e.g., a laptop) is technically `openable` and `pickupable` and it changes position during a shuffle, the `pose_diff["openness_diff"]` will be `0.0` and not `None`.  The if statement does not get triggered and the energy returned will be `0.0` instead of a `>0.0`  value.

Because `pickupable` objects are not opened, as per the paper, we can check `goal_pose["pickupable"]` explicitly.